### PR TITLE
Output storage accounts actual name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "storageaccount_id" {
 }
 
 output "storageaccount_name" {
-  value = "${var.storage_account_name}"
+  value       = "${azurerm_storage_account.storage_account.name}"
   description = "The storage account name."
 }
 


### PR DESCRIPTION
Don't output the supplied account (it may be blank), rather output the
one reported by the storage account.