### PR TITLE
Module updated to v3 of Terraform provider

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  TF_VERSION: 0.15.4
+  TF_VERSION: 1.1.7
 
 jobs:
   terraform:

--- a/main.tf
+++ b/main.tf
@@ -20,16 +20,16 @@ locals {
 }
 
 resource "azurerm_storage_account" "storage_account" {
-  name                      = local.storage_account_name
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  account_kind              = var.account_kind
-  account_tier              = var.account_tier
-  account_replication_type  = var.account_replication_type
-  access_tier               = var.access_tier
-  enable_https_traffic_only = var.enable_https_traffic_only
-  min_tls_version           = "TLS1_2"
-  allow_blob_public_access  = var.allow_blob_public_access
+  name                            = local.storage_account_name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  account_kind                    = var.account_kind
+  account_tier                    = var.account_tier
+  account_replication_type        = var.account_replication_type
+  access_tier                     = var.access_tier
+  enable_https_traffic_only       = var.enable_https_traffic_only
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = var.allow_nested_items_to_be_public
 
 
   dynamic "blob_properties" {

--- a/test/with-provided-name/provider.tf
+++ b/test/with-provided-name/provider.tf
@@ -1,3 +1,3 @@
 provider "azurerm" {
-  version = ">= 1.9.0"
+  version = "= 3.0.1"
 }

--- a/test/with-random-name/provider.tf
+++ b/test/with-random-name/provider.tf
@@ -1,3 +1,3 @@
 provider "azurerm" {
-  version = ">= 1.9.0"
+  version = "= 3.0.1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "enable_https_traffic_only" {
   default     = "true"
 }
 
-variable "allow_blob_public_access" {
+variable "allow_nested_items_to_be_public" {
   description = "(Optional) Allow or disallow public access to all blobs or containers in the storage account. Defaults to false."
   default     = "false"
 }


### PR DESCRIPTION
### Change description ###
field allow_blob_public_access renamed to allow_nested_items_to_be_public  due to update to v3 of Az Rm provider


**Does this PR introduce a breaking change?** (check one with "x")
Repo's using this repo will need to update their reference or keep their provider at <= 2.99.0 

```
[X] Yes  
[] No
```
