### PR TITLE
enable_change_feed needs its default to be set to true

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -180,7 +180,7 @@ variable "private_endpoint_subnet_id" {
 }
 
 variable "enable_change_feed" {
-  default = "false"
+  default = "true"
 }
 
 variable "immutable_enabled" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###
enable_change_feed needs to be set to "true" or the storage account deployment will fail. If this is not explicitly set to "true" in values supplied to this module, any code that uses this module will break. See error below:

│ Error: `change_feed_enabled` must be `true` when `restore_policy` is set

See Terraform Documentation here: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#restore_policy

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
