### PR TITLE
Make restore_policy a non-breaking change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,8 @@ resource "azurerm_storage_account" "storage_account" {
         days = 365
       }
       restore_policy {
-        days = var.restore_policy_days
+        count = var.restore_policy_days != "0" ? 1 : 0
+        days  = var.restore_policy_days
       }
       dynamic "cors_rule" {
         for_each = var.cors_rules

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,9 @@ resource "azurerm_storage_account" "storage_account" {
       delete_retention_policy {
         days = 365
       }
-      restore_policy {
-        days = var.restore_policy_days != null ? var.restore_policy_days : null
+      dynamic "restore_policy" {
+        for_each = var.restore_policy_days != null ? [1] : []
+        days     = var.restore_policy_days
       }
       dynamic "cors_rule" {
         for_each = var.cors_rules

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,7 @@ resource "azurerm_storage_account" "storage_account" {
         days = 365
       }
       restore_policy {
-        count = var.restore_policy_days != "0" ? 1 : 0
-        days  = var.restore_policy_days
+        days = try(var.restore_policy_days, null)
       }
       dynamic "cors_rule" {
         for_each = var.cors_rules

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,9 @@ resource "azurerm_storage_account" "storage_account" {
       }
       dynamic "restore_policy" {
         for_each = var.restore_policy_days != null ? [1] : []
-        days     = var.restore_policy_days
+        content {
+          days = var.restore_policy_days
+        }
       }
       dynamic "cors_rule" {
         for_each = var.cors_rules

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_storage_account" "storage_account" {
         days = 365
       }
       restore_policy {
-        days = try(var.restore_policy_days, null)
+        days = var.restore_policy_days != null ? var.restore_policy_days : null
       }
       dynamic "cors_rule" {
         for_each = var.cors_rules

--- a/variables.tf
+++ b/variables.tf
@@ -192,5 +192,5 @@ variable "immutability_period" {
 }
 
 variable "restore_policy_days" {
-  default = "0"
+  default = "1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -192,5 +192,5 @@ variable "immutability_period" {
 }
 
 variable "restore_policy_days" {
-  default = "1"
+  default = "0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -192,5 +192,5 @@ variable "immutability_period" {
 }
 
 variable "restore_policy_days" {
-  default = "1"
+  default = null
 }


### PR DESCRIPTION
### Change description ###
when the restore_policy field was added, it broke my build as this option is not compatible with storage accounts with immutability enabled. This change makes the restore_policy optional.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
