### PR TITLE
Drop .git from module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Minimal example:
 
 ```terraform
 module "this" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account.git?ref=master"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
   env                      = var.env
   storage_account_name     = var.storage_account_name
   resource_group_name      = var.resource_group_name
@@ -26,7 +26,7 @@ More options:
 
 ```terraform
 module "this" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account.git?ref=master"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
   env                      = var.env
   storage_account_name     = var.storage_account_name
   resource_group_name      = var.resource_group_name
@@ -97,7 +97,7 @@ data "azurerm_subnet" "private_endpoints" {
 }
 
 module "this" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account.git?ref=master"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
   env                      = var.env
   storage_account_name     = var.storage_account_name
   resource_group_name      = var.resource_group_name
@@ -173,7 +173,7 @@ Ensure:
 
 ```terraform
 module "sftp_storage" {
-  source                   = "git@github.com:hmcts/cnp-module-storage-account.git?ref=master"
+  source                   = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
   
   ...
   


### PR DESCRIPTION
Minor niggle but convention here is without .git and breaks builds when jenkins checks for modules allowed for deployment

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
