### PR TITLE
DTSPO-15546 Add PIM support for limited roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,14 @@ To actually connect via SFTP, you will require a local user for the storage acco
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | n/a |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [azapi_update_resource.defender_settings](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azurerm_pim_eligible_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/pim_eligible_role_assignment) | resource |
 | [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_role_assignment.storage-account-role-assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_storage_account.storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
@@ -214,6 +216,11 @@ To actually connect via SFTP, you will require a local user for the storage acco
 | [azurerm_storage_management_policy.storage-account-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_table.tables](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
 | [random_string.storage_account_random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [time_rotating.rotate](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
+| [time_static.pim_expiry](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
+| [time_static.pim_start](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
+| [azurerm_role_definition.role_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/role_definition) | data source |
+| [azurerm_subscription.primary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -249,6 +256,7 @@ To actually connect via SFTP, you will require a local user for the storage acco
 | <a name="input_ip_rules"></a> [ip\_rules](#input\_ip\_rules) | (Optional) List of public IP addresses which will have access to storage account. | `list(string)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | `"uksouth"` | no |
 | <a name="input_managed_identity_object_id"></a> [managed\_identity\_object\_id](#input\_managed\_identity\_object\_id) | (Optional) Object Id for a Managed Identity to assign roles to, scoped to this storage account. | `string` | `""` | no |
+| <a name="input_pim_roles"></a> [pim\_roles](#input\_pim\_roles) | { 'Role name' = { principal\_id = 'principal\_id' } }, only certain roles are supported | <pre>map(object({<br>    principal_id = string<br>  }))</pre> | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | Storage Account Managment Policy | <pre>list(object({<br>    name = string<br>    filters = object({<br>      prefix_match = list(string)<br>      blob_types   = list(string)<br>    })<br>    actions = object({<br>      version_delete_after_days_since_creation = number<br>    })<br>  }))</pre> | `[]` | no |
 | <a name="input_private_endpoint_subnet_id"></a> [private\_endpoint\_subnet\_id](#input\_private\_endpoint\_subnet\_id) | Subnet ID to attach private endpoint to - overrides the default subnet id | `string` | `""` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | This is the prefix your resource group name will have for your shared infrastructure | `string` | n/a | yes |

--- a/example/main.tf
+++ b/example/main.tf
@@ -21,6 +21,8 @@ data "azurerm_subnet" "private_endpoints" {
   name                 = "private-endpoints"
 }
 
+data "azurerm_client_config" "this" {}
+
 module "this" {
   source                     = "../"
   env                        = var.env

--- a/pim.tf
+++ b/pim.tf
@@ -1,0 +1,38 @@
+resource "time_rotating" "rotate" {
+  rotation_days = 360
+}
+
+resource "time_static" "pim_expiry" {
+  rfc3339 = time_rotating.rotate.rotation_rfc3339
+}
+
+resource "time_static" "pim_start" {}
+
+data "azurerm_subscription" "primary" {
+}
+
+data "azurerm_role_definition" "role_name" {
+  for_each = local.pim_roles
+
+  name  = each.key
+  scope = data.azurerm_subscription.primary.id
+}
+
+locals {
+  pim_roles = { for role, value in var.pim_roles : role => value if contains(local.allowed_roles, role) }
+}
+
+resource "azurerm_pim_eligible_role_assignment" "this" {
+  for_each = local.pim_roles
+
+  scope              = azurerm_storage_account.storage_account.id
+  role_definition_id = data.azurerm_role_definition.role_name[each.key].id
+  principal_id       = each.value.principal_id
+
+  schedule {
+    start_date_time = time_static.pim_start.rfc3339
+    expiration {
+      end_date_time = time_static.pim_expiry.rfc3339
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -222,6 +222,6 @@ variable "pim_roles" {
   type = map(object({
     principal_id = string
   }))
-  default = null
+  default     = null
   description = "{ 'Role name' = { principal_id = 'principal_id' } }, only certain roles are supported"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,13 @@ variable "defender_override_subscription_level_settings" {
   default     = true
   description = "Whether to override subscription level settings"
 }
+
+// PIM
+
+variable "pim_roles" {
+  type = map(object({
+    principal_id = string
+  }))
+  default = null
+  description = "{ 'Role name' = { principal_id = 'principal_id' } }, only certain roles are supported"
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15546
https://tools.hmcts.net/jira/browse/DTSRD-1205


### Change description ###

Allows limited roles to be enabled for user based access using PIM.

Example:
```terraform
module "this" {
  source                     = "git@github.com:hmcts/cnp-module-storage-account?ref=master"
  env                          = var.env
  ...

  # only enabled on prod
  pim_roles = var.env != prod ? null : {
    "Storage Blob Delegator" = {
      principal_id = "..."
    }

    "Storage Blob Data Reader" = {
      principal_id = "..."
    }

    # will be filtered out as it's not an allowed role
    "Owner" = {
      principal_id = "..."
    }
  }
}

```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
