### PR TITLE
DTSPO-18648 adding cross tenant replication

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,20 +20,21 @@ locals {
 }
 
 resource "azurerm_storage_account" "storage_account" {
-  name                            = local.storage_account_name
-  resource_group_name             = var.resource_group_name
-  location                        = var.location
-  account_kind                    = var.account_kind
-  account_tier                    = var.account_tier
-  account_replication_type        = var.account_replication_type
-  access_tier                     = var.access_tier
-  https_traffic_only_enabled      = var.enable_https_traffic_only
-  min_tls_version                 = "TLS1_2"
-  allow_nested_items_to_be_public = var.allow_nested_items_to_be_public
-  sftp_enabled                    = var.enable_sftp
-  is_hns_enabled                  = var.enable_hns
-  nfsv3_enabled                   = var.enable_nfs
-  public_network_access_enabled   = var.public_network_access_enabled
+  name                             = local.storage_account_name
+  resource_group_name              = var.resource_group_name
+  location                         = var.location
+  account_kind                     = var.account_kind
+  account_tier                     = var.account_tier
+  account_replication_type         = var.account_replication_type
+  access_tier                      = var.access_tier
+  https_traffic_only_enabled       = var.enable_https_traffic_only
+  min_tls_version                  = "TLS1_2"
+  allow_nested_items_to_be_public  = var.allow_nested_items_to_be_public
+  sftp_enabled                     = var.enable_sftp
+  is_hns_enabled                   = var.enable_hns
+  nfsv3_enabled                    = var.enable_nfs
+  public_network_access_enabled    = var.public_network_access_enabled
+  cross_tenant_replication_enabled = var.cross_tenant_replication_enabled
 
   dynamic "immutability_policy" {
     for_each = var.immutable_enabled == true ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "role_assignments" {
 variable "cross_tenant_replication_enabled" {
   type        = bool
   description = "(Optional) Should cross Tenant replication be enabled"
-  default     = true
+  default     = false
 }
 
 // TAG SPECIFIC VARIABLES

--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,12 @@ variable "role_assignments" {
   default     = []
 }
 
+variable "cross_tenant_replication_enabled" {
+  type        = bool
+  description = "(Optional) Should cross Tenant replication be enabled"
+  default     = true
+}
+
 // TAG SPECIFIC VARIABLES
 variable "common_tags" {
   type = map(string)


### PR DESCRIPTION
### Jira link

[DTSPO-18648](https://tools.hmcts.net/jira/browse/DTSPO-18648)

### Change description

ops-jumpboxes repo was using azurerm provider 3.7.0 where cross tenant replication is set to default true. The repo is now using provider version 4.1.0 which sets cross tenant replication to false by default and is causing changes in production.

adding this code to prevent those changes.


