### PR TITLE
Fix for change in azapi structure

### DIFF
--- a/defender.tf
+++ b/defender.tf
@@ -2,7 +2,7 @@ resource "azapi_update_resource" "defender_settings" {
   name      = "current"
   type      = "Microsoft.Security/DefenderForStorageSettings@2022-12-01-preview"
   parent_id = azurerm_storage_account.storage_account.id
-  body = jsonencode({
+  body = {
     properties = {
       isEnabled = var.defender_enabled
       malwareScanning = {
@@ -16,5 +16,5 @@ resource "azapi_update_resource" "defender_settings" {
       }
       overrideSubscriptionLevelSettings = var.defender_override_subscription_level_settings
     }
-  })
+  }
 }


### PR DESCRIPTION
### Change description

Fixes error caused by update in azapi update_resource call. `body` is now an object not a json string. https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource

### Testing done
Tested here: 
https://github.com/hmcts/pre-shared-infrastructure/pull/923/files
